### PR TITLE
make go Emit be asynchronous from receipt of message from frontend

### DIFF
--- a/wails.go
+++ b/wails.go
@@ -3,6 +3,7 @@ package main
 import (
 	"log"
 	"sync"
+	"time"
 
 	"github.com/wailsapp/wails"
 )
@@ -28,8 +29,14 @@ func (mb *MyBridge) wailsRunner() {
 			mb.Lock()
 			mb.status = newStat
 			mb.Unlock()
-			mb.Runtime.Events.Emit("update_status", newStat)
 		}
+	}
+}
+
+func (mb *MyBridge) updateStatus() {
+	for {
+		mb.Runtime.Events.Emit("update_status", mb.status)
+		time.Sleep(1 * time.Second)
 	}
 }
 
@@ -42,6 +49,7 @@ func (mb *MyBridge) WailsInit(r *wails.Runtime) error {
 	})
 
 	go mb.wailsRunner()
+	go mb.updateStatus()
 
 	return nil
 }


### PR DESCRIPTION
I moved the Events.Emit to a separate goroutine from the one receiving the messages in the first place.

This seems to avoid the crash you were encountering.

It's not easy to swap in a read/write lock on the websocket connection because of Gorilla's blocking read.  I am still looking into it further but perhaps this will enable you to proceed with development.

I couldn't figure out how to make the `increment` button emit a message that would cause the status to change on the backend and then be emitted to the frontend again.  I have no idea how your javascript library works in this respect.  